### PR TITLE
Remove Kevin Chu from governing committee

### DIFF
--- a/governance-charter.md
+++ b/governance-charter.md
@@ -21,9 +21,9 @@ Members of the governing committee:
 - [Michael Beemer](https://github.com/beeme1mr), Dynatrace, term: April 28, 2022 - TBD
 - [Ben Rometsch](https://github.com/dabeeeenster), Flagsmith, term: April 28, 2022 - TBD
 - [Justin Abrahms](https://github.com/justinabrahms), eBay, term: April 28, 2022 - TBD
-- [Kevin Chu](https://github.com/kbychu), GitLab, term: April 28, 2022 - TBD
 - [Pete Hodgson](https://github.com/moredip), Independent, term: April 28, 2022 - TBD
 - [Alois Reitbauer](https://github.com/aloisreitbauer), Dynatrace, term: Oct 1st, 2022 - TBD
+- Vacant
 - Vacant
 
 > NOTE:


### PR DESCRIPTION
Kevin does not have the bandwidth to adequately contribute to Open Feature. It is beneficial to have a governing committee who have more to contribute.